### PR TITLE
Add .cmd and .bat file imports

### DIFF
--- a/src/renderer/src/components/CatalogManager.tsx
+++ b/src/renderer/src/components/CatalogManager.tsx
@@ -88,7 +88,7 @@ function parseBatContent(content: string): BatParseResult {
     if (fileIndex >= 0) {
       for (let i = fileIndex + 1; i < tokens.length; i++) {
         const token = tokens[i]
-        if (token.startsWith('-')) break
+        if (token.startsWith('-') || token.startsWith('+')) break
         modFiles.push(token)
       }
     }
@@ -446,15 +446,16 @@ export function CatalogManager({ files, onChange }: CatalogManagerProps): React.
         filters: [
           {
             name: 'Mod stuff',
-            extensions: ['wad', 'pk3', 'pk7', 'ipk3', 'deh', 'bex', 'zip', 'bat']
+            extensions: ['wad', 'pk3', 'pk7', 'ipk3', 'deh', 'bex', 'zip', 'bat', 'cmd']
           }
         ]
       })
 
       if (!result.canceled && result.filePaths.length > 0) {
         const selectedPath = result.filePaths[0]
+        const lowerPath = selectedPath.toLowerCase()
 
-        if (selectedPath.toLowerCase().endsWith('.bat')) {
+        if (lowerPath.endsWith('.bat') || lowerPath.endsWith('.cmd')) {
           try {
             const content = await api.readFile(selectedPath)
             const parsed = parseBatContent(content)
@@ -489,10 +490,10 @@ export function CatalogManager({ files, onChange }: CatalogManagerProps): React.
             setAddForm((prev) => ({ ...prev, ...updatedForm }) as typeof addForm)
             setIsAddModalOpen(true)
           } catch (error) {
-            console.error('Failed to parse .bat:', error)
+            console.error('Failed to parse script:', error)
             toast({
               title: 'Error',
-              description: 'Failed to parse .bat file',
+              description: 'Failed to parse script file',
               variant: 'destructive'
             })
           }
@@ -533,17 +534,18 @@ export function CatalogManager({ files, onChange }: CatalogManagerProps): React.
       const droppedPath = window.api.getPathForFile(file) || file.name
 
       const ext = droppedPath.split('.').pop()?.toUpperCase()
-      const validExtensions = ['WAD', 'PK3', 'PK7', 'IPK3', 'DEH', 'BEX', 'ZIP', 'BAT']
+      const validExtensions = ['WAD', 'PK3', 'PK7', 'IPK3', 'DEH', 'BEX', 'ZIP', 'BAT', 'CMD']
       if (!ext || !validExtensions.includes(ext)) {
         toast({
           title: 'FATAL: type_unknow',
-          description: 'Please only use supported files: wad, pk3, pk7, ipk3, deh, bex, zip, bat',
+          description:
+            'Please only use supported files: wad, pk3, pk7, ipk3, deh, bex, zip, bat, cmd',
           variant: 'destructive'
         })
         return
       }
 
-      if (ext === 'BAT') {
+      if (ext === 'BAT' || ext === 'CMD') {
         try {
           const content = await file.text()
           const parsed = parseBatContent(content)
@@ -552,7 +554,7 @@ export function CatalogManager({ files, onChange }: CatalogManagerProps): React.
           if (resolvedFiles.length === 0) {
             toast({
               title: 'Error',
-              description: 'No -file entries found in .bat file',
+              description: 'No -file entries found in script file',
               variant: 'destructive'
             })
             return
@@ -578,10 +580,10 @@ export function CatalogManager({ files, onChange }: CatalogManagerProps): React.
           setAddForm((prev) => ({ ...prev, ...updatedForm }) as typeof addForm)
           setIsAddModalOpen(true)
         } catch (error) {
-          console.error('Failed to parse .bat:', error)
+          console.error('Failed to parse script:', error)
           toast({
             title: 'Error',
-            description: 'Failed to parse .bat file',
+            description: 'Failed to parse script file',
             variant: 'destructive'
           })
         }

--- a/src/renderer/src/pages/InstallPage.tsx
+++ b/src/renderer/src/pages/InstallPage.tsx
@@ -110,7 +110,7 @@ function parseBatContent(content: string): BatParseResult {
   if (fileIndex >= 0) {
     for (let i = fileIndex + 1; i < tokens.length; i++) {
       const token = tokens[i]
-      if (token.startsWith('-')) {
+      if (token.startsWith('-') || token.startsWith('+')) {
         extraParams.push(...tokens.slice(i))
         break
       }
@@ -585,13 +585,15 @@ export const InstallPage: React.FC = () => {
       const droppedFile = e.dataTransfer.files[0]
       if (!droppedFile) return
 
-      // Handle .bat file drops
-      if (droppedFile.name.toLowerCase().endsWith('.bat')) {
+      // Handle .bat / .cmd file drops
+      const lowerName = droppedFile.name.toLowerCase()
+      if (lowerName.endsWith('.bat') || lowerName.endsWith('.cmd')) {
         try {
           const text = await droppedFile.text()
           const parsed = parseBatContent(text)
 
-          const baseName = droppedFile.name.replace(/\.bat$/i, '')
+          const ext = lowerName.endsWith('.bat') ? '.bat' : '.cmd'
+          const baseName = droppedFile.name.replace(new RegExp(`\\${ext}$`, 'i'), '')
           form.setValue('title', baseName)
 
           // Match source port
@@ -610,12 +612,14 @@ export const InstallPage: React.FC = () => {
             if (defaultPort) form.setValue('sourcePortId', defaultPort.id)
           }
 
-          // Match doom version by iwad (case-insensitive)
+          // Match doom version by iwad (case-insensitive, basename only)
           if (parsed.iwad && versions.length > 0) {
-            const iwadLower = parsed.iwad.toLowerCase()
-            const matchedVersion = versions.find(
-              (v) => v.defaultIwad && v.defaultIwad.toLowerCase() === iwadLower
-            )
+            const iwadLower = parsed.iwad.toLowerCase().split(/[\\/]/).pop() || ''
+            const matchedVersion = versions.find((v) => {
+              if (!v.defaultIwad) return false
+              const versionIwadName = v.defaultIwad.toLowerCase().split(/[\\/]/).pop() || ''
+              return versionIwadName === iwadLower
+            })
             if (matchedVersion) {
               form.setValue('doomVersionId', matchedVersion.id.toString())
             }
@@ -694,7 +698,7 @@ export const InstallPage: React.FC = () => {
       if (!droppedFile.name.endsWith('.json')) {
         toast({
           title: 'Invalid file',
-          description: 'Please drop a JSON or .bat file',
+          description: 'Please drop a JSON, .bat or .cmd file',
           variant: 'destructive'
         })
         return


### PR DESCRIPTION
## **Install page** 
it parses: 
- Source Port
- Base game wad
- Mod files
- Launch parameters

Meaning you can now drag and drop a `.cmd` or `.bat` file into the **Install Page** and these options will be prepopulated. It uses the filename as a temporary "Protocol name" 

As always the app checks the mod files that gets addeds md5 sum hash value, and will skip importing files you already have in your modfile catalog, but instead add the catalog ones to the game instance/protocol.

If the `.cmd` or `.bat` file launch command has any additional parameters after the mod files (i.e `-fast`, `-warp 04` `+set gl_precache 1` or similar) will be added as the additional launch parameters for the instance too. I've never seens a launch file dictate the savedir or screenshotdir in the bat file, but it does mean that if the bat/cmd file _does_ have this information, that it will overrule the paths set in the application. 

## Mod File page / Mod file catalog
This will only parse the `-file` arguments. It adds all files to the catalog, letting you set names for all.