### PR TITLE
fix: switch UI scaling from root font-size to Electron zoom

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -322,6 +322,12 @@ app.whenReady().then(async () => {
     autoUpdater.quitAndInstall()
   })
 
+  ipcMain.handle('set-zoom-factor', (_event, factor: number) => {
+    BrowserWindow.getAllWindows().forEach((win) => {
+      win.webContents.setZoomFactor(factor)
+    })
+  })
+
   ipcMain.handle('trigger-fake-update', () => {
     const installType = getInstallType()
     debug(`[FakeUpdate] Install type: ${JSON.stringify(installType)}`)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,7 +30,8 @@ const api = {
   triggerFakeUpdate: () => ipcRenderer.invoke('trigger-fake-update'),
   getInstallType: () => ipcRenderer.invoke('get-install-type'),
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
-  openLogFile: (filePath: string) => ipcRenderer.invoke('open-log-file', filePath)
+  openLogFile: (filePath: string) => ipcRenderer.invoke('open-log-file', filePath),
+  setZoomFactor: (factor: number) => ipcRenderer.invoke('set-zoom-factor', factor)
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -95,12 +95,9 @@ const App: React.FC = () => {
     }
   }, [settings?.theme, settings?.customThemeCss])
 
-  // Apply UI scale globally — sets root font-size as a percentage of the
-  // browser default (16px), so it scales rem-based text/spacing without
-  // touching fixed-px values (borders, etc.). Independent of Electron's
-  // webContents zoom.
+  // Apply UI scale via Electron's built-in zoom factor
   useEffect(() => {
-    document.documentElement.style.fontSize = `${settings?.uiScale ?? 100}%`
+    api.setZoomFactor((settings?.uiScale ?? 100) / 100)
   }, [settings?.uiScale])
 
   useEffect(() => {

--- a/src/renderer/src/api.ts
+++ b/src/renderer/src/api.ts
@@ -421,6 +421,10 @@ export const api = {
     void window.api.triggerFakeUpdate()
   },
 
+  setZoomFactor: (factor: number): void => {
+    void window.api.setZoomFactor(factor)
+  },
+
   // Player data / achievements
   getPlayerData: async (): Promise<IPlayerData> => {
     const response = await fetch(`${API_BASE}/api/player-data`)

--- a/src/renderer/src/components/GameCard.tsx
+++ b/src/renderer/src/components/GameCard.tsx
@@ -99,7 +99,7 @@ export const GameCard: React.FC<GameCardProps> = ({ protocol, doomVersion, onSet
 
         <div
           className="absolute inset-x-0 bottom-0 px-4 py-4 flex justify-between items-end
-                      transform transition-transform duration-300 group-hover:translate-y-[-130px] z-10"
+                      transform transition-transform duration-300 group-hover:translate-y-[-8rem] z-10"
         >
           <h3 className="text-white lg:text-lg font-bold ">{protocol.title}</h3>
 

--- a/src/renderer/src/components/SettingsDialog.tsx
+++ b/src/renderer/src/components/SettingsDialog.tsx
@@ -228,18 +228,16 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
     }
   }, [isOpen, settings.theme, settings.customThemeCss])
 
-  // Live-preview UI scale changes immediately on the DOM
-  useEffect(() => {
-    if (!isOpen || !fetchedRef.current) return
-    document.documentElement.style.fontSize = `${settings.uiScale ?? 100}%`
-  }, [isOpen, settings.uiScale])
+  // Live-preview UI scale is applied on slider release via onValueCommit,
+  // not on every drag tick — Electron zoom moves the viewport which shifts
+  // the slider under the cursor, causing a feedback loop if applied live.
 
   // Restore saved theme/scale when closing without saving
   const handleClose = useCallback((): void => {
     fetchedRef.current = false
     document.documentElement.classList.remove('dark', 'light', 'terminal', 'custom')
     document.documentElement.classList.add(savedRef.current.theme)
-    document.documentElement.style.fontSize = `${savedRef.current.uiScale}%`
+    api.setZoomFactor(savedRef.current.uiScale / 100)
 
     const existingStyle = document.getElementById('custom-theme-style')
     if (savedRef.current.theme === 'custom' && savedRef.current.customThemeCss) {
@@ -668,6 +666,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                     <Slider
                       value={[settings.uiScale ?? 100]}
                       onValueChange={([value]) => setSettings((s) => ({ ...s, uiScale: value }))}
+                      onValueCommit={([value]) => api.setZoomFactor(value / 100)}
                       min={80}
                       max={150}
                       step={5}

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -31,6 +31,7 @@ interface ICustomAPI {
   getInstallType: () => Promise<{ isAppImage: boolean; isSystemInstalled: boolean }>
   getPathForFile: (file: File) => string
   openLogFile: (filePath: string) => Promise<void>
+  setZoomFactor: (factor: number) => Promise<void>
 }
 
 declare global {


### PR DESCRIPTION
- Replace document.documentElement.style.fontSize with webContents.setZoomFactor()
- Scale slider uses onValueCommit instead of onValueChange to avoid feedback loop
- GameCard translate-y uses rem instead of fixed px for scale consistency