### PR TITLE
fix: distinguish sibling files from same UAC registry family

### DIFF
--- a/src/renderer/src/components/CatalogManager.tsx
+++ b/src/renderer/src/components/CatalogManager.tsx
@@ -23,6 +23,7 @@ import { Upload } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { api, IRegistryMod } from '@/api'
 import { dispatchAchievementEvent, buildUnlockToasts } from '@/lib/achievements'
+import { formatRegistryName } from '@/lib/registryName'
 import { REGISTRY_API_URL } from '@shared/registry-config'
 import { CATEGORIES } from '@shared/categories'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -397,10 +398,9 @@ export function CatalogManager({ files, onChange }: CatalogManagerProps): React.
 
     const updatedForm: Partial<typeof addForm> = {
       filePath,
-      name:
-        registryData?.display_name && registryData.display_name !== registryData.family_name
-          ? `${registryData.family_name} — ${registryData.display_name}`
-          : registryData?.family_name || name,
+      name: registryData?.family_name
+        ? formatRegistryName(registryData.family_name, registryData.display_name)
+        : name,
       fileType,
       version: registryData?.version || '',
       url: '',

--- a/src/renderer/src/components/ZipImportModal.tsx
+++ b/src/renderer/src/components/ZipImportModal.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/select'
 import { useToast } from '@/hooks/use-toast'
 import { api, type IRegistryMod } from '@/api'
+import { formatRegistryName } from '@/lib/registryName'
 import { REGISTRY_API_URL } from '@shared/registry-config'
 import { CATEGORIES } from '@shared/categories'
 import type { IModFile } from '@shared/schema'
@@ -186,7 +187,7 @@ export function ZipImportModal({
           if (data) {
             updates.push({
               index: i,
-              name: data.family_name,
+              name: formatRegistryName(data.family_name, data.display_name),
               version: data.version || '',
               url: pickBestUrl(data.urls),
               category: data.category || ''
@@ -239,7 +240,7 @@ export function ZipImportModal({
         if (!hash) return
         const { data } = await doRegistryLookup(hash)
         if (data) {
-          if (data.family_name) setZipName(data.family_name)
+          if (data.family_name) setZipName(formatRegistryName(data.family_name, data.display_name))
           if (data.version) setZipVersion(data.version)
           if (data.category) setZipCategory(data.category)
           const url = pickBestUrl(data.urls)

--- a/src/renderer/src/lib/registryName.ts
+++ b/src/renderer/src/lib/registryName.ts
@@ -7,7 +7,7 @@
  */
 export function formatRegistryName(familyName: string, displayName?: string | null): string {
   if (displayName && displayName !== familyName) {
-    return `${familyName} — ${displayName}`
+    return `${familyName} (${displayName})`
   }
   return familyName
 }

--- a/src/renderer/src/lib/registryName.ts
+++ b/src/renderer/src/lib/registryName.ts
@@ -1,0 +1,13 @@
+/**
+ * A registry family (e.g. "The Abyssal Crown") can bundle several distinct
+ * files (e.g. "Abyssal Core", "Abyssal Crown"), each with its own
+ * display_name. Using family_name alone as every file's display name makes
+ * sibling files indistinguishable in the UI — so whenever a file's
+ * display_name differs from its family_name, show both.
+ */
+export function formatRegistryName(familyName: string, displayName?: string | null): string {
+  if (displayName && displayName !== familyName) {
+    return `${familyName} — ${displayName}`
+  }
+  return familyName
+}

--- a/src/renderer/src/pages/GamesPage.tsx
+++ b/src/renderer/src/pages/GamesPage.tsx
@@ -31,6 +31,7 @@ import GameListCard from '@/components/GameListCard'
 import GameSettingsModal from '@/components/GameSettingsModal'
 import { IProtocol, IDoomVersion, IModFile, IAppSettings } from '@shared/schema'
 import { api } from '@/api'
+import { formatRegistryName } from '@/lib/registryName'
 import { useToast } from '@/hooks/use-toast'
 import type { IRegistryMod, IIdgamesMod } from '@/api'
 import { REGISTRY_API_URL } from '@shared/registry-config'
@@ -180,7 +181,8 @@ export const GamesPage: React.FC = () => {
             if (settings.registryLookupEnabled) {
               const registryData = await api.lookupMod(result.hash, REGISTRY_API_URL)
               if (registryData && registryData.family_name) {
-                setImportFile((prev) => (prev ? { ...prev, name: registryData.family_name } : prev))
+                const name = formatRegistryName(registryData.family_name, registryData.display_name)
+                setImportFile((prev) => (prev ? { ...prev, name } : prev))
               }
             }
           } catch {
@@ -373,9 +375,7 @@ export const GamesPage: React.FC = () => {
                       {registryHits.map((mod, i) => (
                         <div key={i} className="bg-app-card border border-app rounded-lg p-4">
                           <p className="text-sm font-medium text-app-primary truncate">
-                            {mod.display_name && mod.display_name !== mod.family_name
-                              ? `${mod.family_name} — ${mod.display_name}`
-                              : mod.family_name}
+                            {formatRegistryName(mod.family_name, mod.display_name)}
                           </p>
                           <p className="text-xs text-app-muted mt-1">
                             {mod.version && `v${mod.version}`}


### PR DESCRIPTION
Fixes a UAC Registry naming bug — files belonging to the same registry 'family' (e.g. a family bundling 'Abyssal Core' and 'Abyssal Crown') were all displayed using just the family name, making sibling files indistinguishable in the catalog/import UI.

Adds a shared `formatRegistryName(family, display)` helper that shows `<family> (<display>)` whenever a file's own display name differs from its family name. Applies it to the zip-import and idgames-download registry lookups that had this bug, and refactors two pre-existing inline duplicates of the same ternary (in CatalogManager and GamesPage) to use the new shared helper so the convention is defined once.

## Test Plan
Verified end-to-end with a real Electron launch under xvfb, mocking two registry lookup responses that share a `family_name` but have distinct `display_name`s for two files extracted from a real test zip — confirmed both files resolved to distinguishable names (`The Abyssal Crown (Abyssal Core)` / `The Abyssal Crown (Abyssal Crown)`) instead of both collapsing to `The Abyssal Crown`.