### PR TITLE
feat: default Base WAD setting + Configuration tab redesign

### DIFF
--- a/src/main/server/storage.ts
+++ b/src/main/server/storage.ts
@@ -46,6 +46,7 @@ const DEFAULT_DATABASE_LINKS: IDatabaseLink[] = [
 const DEFAULT_SETTINGS: IAppSettings = {
   sourcePorts: [],
   defaultSourcePortId: undefined,
+  defaultDoomVersionId: undefined,
   theme: 'dark',
   savegamesPath: '~/.config/uac/saves',
   modsDirectory: '~/.config/uac/mods',

--- a/src/renderer/src/components/FirstRunTour/tourSteps.ts
+++ b/src/renderer/src/components/FirstRunTour/tourSteps.ts
@@ -162,13 +162,16 @@ export const TOUR_STEPS: TourStepDef[] = [
     title: 'Step 2: Add a Source Port',
     description: `
       <p class="mb-2">
-        While still in the <strong>Path</strong> tab of Settings, click<br />
-        <em>"+ Add Port"</em>, and navigate to your GZDoom, UZDoom, or
+        Source ports have their own tab now. In Settings, go to the
+        <strong>Source Ports</strong> tab and click
+        <em>"+ Add Port"</em>, then navigate to your GZDoom, UZDoom, or
         Zandronum executable, and hit the <strong>Save</strong> button
         on that form after filling out the information.
       </p>
       <p class="mb-2">
         If you have multiple source ports installed, repeat the process for the ones you want to add.
+        The one marked with the highlighted dot is your <strong>default</strong> — it'll be
+        pre-selected whenever you create a new protocol.
       </p>
       <p class="mt-2 text-yellow-400/80 text-xs">
         ⚠ Click the main <strong>Apply</strong> button
@@ -234,9 +237,15 @@ export const TOUR_STEPS: TourStepDef[] = [
       <p class="mb-2">
         The tour has taken you back to INSTALL → <strong>Configuration</strong>. Hit <code>i</code> any time to get back here.
       </p>
+      <p class="mb-2">
+        Fill in at least a <strong>label</strong> under <em>Protocol Identity</em>.
+        Base WAD and source port are already pre-filled from your defaults —
+        open <strong>Advanced</strong> below if you'd rather pick different ones
+        for this protocol.
+      </p>
       <p>
-        Fill in at least a <strong>title</strong>, select a <strong>base wad</strong> and optionally add <strong>mod files</strong>,
-        before clicking the <strong>Create Protocol</strong> button at the bottom.
+        Optionally add <strong>mod files</strong>, then click the
+        <strong>Create Protocol</strong> button at the bottom.
       </p>
     `,
     placement: 'bottom-right',

--- a/src/renderer/src/components/SettingsDialog.tsx
+++ b/src/renderer/src/components/SettingsDialog.tsx
@@ -34,6 +34,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
   const [settings, setSettings] = useState<IAppSettings>({
     sourcePorts: [],
     defaultSourcePortId: undefined,
+    defaultDoomVersionId: undefined,
     theme: 'dark',
     savegamesPath: '',
     modsDirectory: '',
@@ -164,6 +165,10 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
     })
   }
 
+  const handleSetDefaultDoomVersion = (id: string): void => {
+    setSettings((prev) => ({ ...prev, defaultDoomVersionId: id }))
+  }
+
   const handleIconBrowse = async (index: number): Promise<void> => {
     const version = doomVersions[index]
     const result = await api.showOpenDialog({
@@ -266,6 +271,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
       const payload = {
         sourcePorts: settings.sourcePorts,
         defaultSourcePortId: settings.defaultSourcePortId,
+        defaultDoomVersionId: settings.defaultDoomVersionId,
         savegamesPath: settings.savegamesPath,
         modsDirectory: settings.modsDirectory,
         screenshotsPath: settings.screenshotsPath,
@@ -818,15 +824,32 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                     <div className="flex flex-col overflow-y-auto border-r border-app bg-app-secondary/20 scrollbar-thin scrollbar-thumb-app-hover">
                       <div className="p-2 space-y-1">
                         {doomVersions.map((version, index) => (
-                          <button
+                          <div
                             key={version.id || index}
                             onClick={() => setSelectedWadIndex(index)}
-                            className={`flex items-center gap-3 p-3 rounded-lg transition-all text-left group shrink-0 border border-transparent ${
+                            className={`flex items-center gap-2.5 p-3 rounded-lg transition-all text-left group shrink-0 border border-transparent cursor-pointer ${
                               selectedWadIndex === index
                                 ? 'bg-app-primary border-app shadow-sm outline-accent-highlight/30 outline-1'
                                 : 'hover:bg-app-primary/40'
                             }`}
                           >
+                            {/* Default indicator */}
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                handleSetDefaultDoomVersion(version.id)
+                              }}
+                              className={`shrink-0 w-4 h-4 rounded-full border-2 transition-colors ${
+                                settings.defaultDoomVersionId === version.id
+                                  ? 'border-accent-highlight bg-accent-highlight'
+                                  : 'border-app-muted/40 hover:border-app-muted'
+                              }`}
+                              title={
+                                settings.defaultDoomVersionId === version.id
+                                  ? 'Default WAD — pre-fills Base WAD on new protocols'
+                                  : 'Set as default WAD'
+                              }
+                            />
                             <div className="w-8 h-8 shrink-0 flex items-center justify-center overflow-hidden rounded bg-black/20 group-hover:bg-black/40 transition-colors">
                               <DoomVersionIcon
                                 version={version.slug}
@@ -843,7 +866,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                             >
                               {version.name}
                             </span>
-                          </button>
+                          </div>
                         ))}
                       </div>
                     </div>

--- a/src/renderer/src/components/SettingsDialog.tsx
+++ b/src/renderer/src/components/SettingsDialog.tsx
@@ -757,8 +757,11 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
               <SourcePortsTab settings={settings} setSettings={setSettings} />
             </TabsContent>
 
-            <TabsContent value="wad-config" className="flex-1 min-h-0 pt-0 flex flex-col">
-              <div className="p-4 border-b border-app bg-app-secondary/30 space-y-3 shrink-0">
+            <TabsContent
+              value="wad-config"
+              className="flex-1 min-h-0 p-6 flex flex-col gap-4 overflow-hidden"
+            >
+              <div className="bg-app-secondary p-4 rounded-xl border border-app shadow-sm space-y-3 shrink-0">
                 <Label className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
                   FreeDoom
                 </Label>
@@ -806,7 +809,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                 {freedoomError && <p className="text-xs text-red-400">{freedoomError}</p>}
               </div>
 
-              <div className="flex-1 min-h-0">
+              <div className="flex-1 min-h-0 bg-app-secondary rounded-xl border border-app shadow-sm overflow-hidden flex flex-col">
                 {isLoadingVersions ? (
                   <div className="flex items-center justify-center h-full gap-3 text-app-secondary font-mono italic">
                     <div className="w-2 h-2 rounded-full bg-accent-highlight animate-pulse" />
@@ -821,7 +824,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                 ) : (
                   <div className="grid grid-cols-[240px,1fr] h-full overflow-hidden">
                     {/* Master: WAD List Sidebar */}
-                    <div className="flex flex-col overflow-y-auto border-r border-app bg-app-secondary/20 scrollbar-thin scrollbar-thumb-app-hover">
+                    <div className="flex flex-col overflow-y-auto border-r border-app bg-app-primary/20 scrollbar-thin scrollbar-thumb-app-hover">
                       <div className="p-2 space-y-1">
                         {doomVersions.map((version, index) => (
                           <div
@@ -872,11 +875,11 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                     </div>
 
                     {/* Detail: WAD Settings Editor */}
-                    <div className="flex flex-col gap-8 overflow-y-auto p-6 scrollbar-thin scrollbar-thumb-app-hover bg-app-primary">
+                    <div className="flex flex-col gap-8 overflow-y-auto p-6 scrollbar-thin scrollbar-thumb-app-hover">
                       {doomVersions[selectedWadIndex] && (
                         <>
                           <div className="flex items-start gap-6">
-                            <div className="w-32 h-32 rounded-xl bg-app-secondary border border-app shadow-2xl group relative overflow-hidden shrink-0 flex items-center justify-center p-2 transition-transform hover:scale-[1.02]">
+                            <div className="w-32 h-32 rounded-xl bg-app-primary border border-app shadow-2xl group relative overflow-hidden shrink-0 flex items-center justify-center p-2 transition-transform hover:scale-[1.02]">
                               <DoomVersionIcon
                                 version={doomVersions[selectedWadIndex].slug}
                                 customIcon={doomVersions[selectedWadIndex].icon}
@@ -899,14 +902,14 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                                   onChange={(e) =>
                                     handleVersionChange(selectedWadIndex, 'name', e.target.value)
                                   }
-                                  className="bg-app-secondary border-app h-11 text-base focus-visible:ring-accent-highlight/40"
+                                  className="bg-app-primary border-app h-11 text-base focus-visible:ring-accent-highlight/40"
                                 />
                               </div>
                               {/* Engine Runtime removed — source port is now configured per-game via ISourcePort */}
                             </div>
                           </div>
 
-                          <div className="space-y-4 p-5 bg-app-secondary border border-app rounded-xl shadow-lg">
+                          <div className="space-y-4 p-5 bg-app-primary border border-app rounded-xl shadow-lg">
                             <Label className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold block">
                               Technical Parameters
                             </Label>
@@ -920,7 +923,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                                   onChange={(e) =>
                                     handleVersionChange(selectedWadIndex, 'args', e.target.value)
                                   }
-                                  className="bg-app-primary border-app h-10 text-sm text-app-primary focus-visible:ring-accent-highlight/40"
+                                  className="bg-app-secondary border-app h-10 text-sm text-app-primary focus-visible:ring-accent-highlight/40"
                                 />
                               </div>
                               <div className="flex flex-col gap-2">
@@ -936,7 +939,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({ isOpen, onClose 
                                       e.target.value
                                     )
                                   }
-                                  className="bg-app-primary border-app h-10 text-sm text-app-primary focus-visible:ring-accent-highlight/40"
+                                  className="bg-app-secondary border-app h-10 text-sm text-app-primary focus-visible:ring-accent-highlight/40"
                                   placeholder="e.g. -nomonsters -warp 01"
                                 />
                               </div>

--- a/src/renderer/src/components/install/ConfigurationTab.tsx
+++ b/src/renderer/src/components/install/ConfigurationTab.tsx
@@ -213,7 +213,17 @@ export const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
                   <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
                     Base WAD
                   </FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
+                  {/* key forces a fresh mount the instant a value is first
+                      set programmatically (our default-fill effect in
+                      InstallPage) — without it, Radix Select's onValueChange
+                      spontaneously fires with '' right after a value is set
+                      on an already-mounted-empty instance, resetting the
+                      pre-fill before the user ever sees it. */}
+                  <Select
+                    key={field.value ? 'has-value' : 'no-value'}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                  >
                     <FormControl>
                       <SelectTrigger className="bg-app-primary border-app">
                         <SelectValue placeholder="Select Base Game/Version" />

--- a/src/renderer/src/components/install/ConfigurationTab.tsx
+++ b/src/renderer/src/components/install/ConfigurationTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import type { UseMutationResult } from '@tanstack/react-query'
 import type { IModFile, IAppSettings, IDoomVersion, IProtocol } from '@shared/schema'
 import { slugify } from '@/lib/utils'
@@ -14,6 +14,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Select,
   SelectContent,
@@ -25,8 +26,7 @@ import { Combobox } from '@/components/ui/combobox'
 import { Separator } from '@/components/ui/separator'
 import { ModFileSelector } from '@/components/ModFileSelector'
 import { LaunchCommandPreview } from '@/components/install/LaunchCommandPreview'
-import { ProtocolConfigControl } from '@/components/ProtocolConfigControl'
-import { FolderOpen, FlaskConical, Plus } from 'lucide-react'
+import { FolderOpen, FlaskConical, Plus, ChevronDown } from 'lucide-react'
 import type { UseFormReturn } from 'react-hook-form'
 import type { z } from 'zod'
 import type { formSchema } from '@/lib/install/schema'
@@ -52,15 +52,18 @@ export interface ConfigurationTabProps {
   toast: ToastLike
   onSubmit: (data: z.infer<typeof formSchema>) => Promise<void>
   handleFilesChange: (newFiles: IModFile[]) => void
-  configStatus: { hasConfig: boolean; statusText: string }
-  onCreateFreshConfig: () => void
-  isCreatingConfig: boolean
+  /** Name of the mod file that would auto-seed a config, if any — shown as a
+   *  note next to the isolated-config checkbox since checking it overrides
+   *  that auto-seed. */
+  templateSeedName: string | null
 }
 
 /**
  * The "Configuration" tab content — the main form for creating a new launch protocol.
- * Includes fields for title, screenshot, description, base WAD, source port, save dir,
- * launch parameters, drag-reorderable mod file selection, launch preview, and submit.
+ * Grouped into a "Protocol Identity" panel (label, cover, description — the fields
+ * that make a protocol recognizable in the library) and a collapsed "Advanced"
+ * section (base WAD / source port overrides, save dir, launch parameters, isolated
+ * config), plus drag-reorderable mod file selection, launch preview, and submit.
  */
 export const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
   form,
@@ -73,15 +76,21 @@ export const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
   toast,
   onSubmit,
   handleFilesChange,
-  configStatus,
-  onCreateFreshConfig,
-  isCreatingConfig
+  templateSeedName
 }) => {
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const isolatedConfigChecked = form.watch('isolatedConfig')
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="space-y-4">
+        {/* Protocol Identity — what makes this protocol recognizable */}
+        <div className="bg-app-secondary p-4 rounded-xl border border-app shadow-sm space-y-4">
+          <span className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
+            Protocol Identity
+          </span>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <FormField
               control={form.control}
               name="title"
@@ -183,145 +192,192 @@ export const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
                 </FormItem>
               )}
             />
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
-                    Description (Optional)
-                  </FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder="Enter a fitting description"
-                      className="bg-app-primary border-app h-[126px]"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
           </div>
 
-          <div className="space-y-4">
-            <FormField
-              control={form.control}
-              name="doomVersionId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
-                    Base WAD
-                  </FormLabel>
-                  {/* key forces a fresh mount the instant a value is first
-                      set programmatically (our default-fill effect in
-                      InstallPage) — without it, Radix Select's onValueChange
-                      spontaneously fires with '' right after a value is set
-                      on an already-mounted-empty instance, resetting the
-                      pre-fill before the user ever sees it. */}
-                  <Select
-                    key={field.value ? 'has-value' : 'no-value'}
-                    onValueChange={field.onChange}
-                    value={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="bg-app-primary border-app">
-                        <SelectValue placeholder="Select Base Game/Version" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent className="bg-app-secondary border-app text-app-primary">
-                      {versions
-                        .filter((v) => !v.ignored)
-                        .map((version) => (
-                          <SelectItem key={version.id} value={version.id.toString()}>
-                            {version.name}
-                          </SelectItem>
-                        ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="sourcePortId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
-                    Source Port
-                  </FormLabel>
-                  <FormControl>
-                    <Combobox
-                      value={field.value}
-                      onValueChange={field.onChange}
-                      options={(settings?.sourcePorts || [])
-                        .filter((p) => !p.ignored)
-                        .map((p) => ({
-                          value: p.id,
-                          label: p.name,
-                          description: p.version
-                        }))}
-                      placeholder="Select a source port"
-                      className="w-full bg-app-primary border-app"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="saveDirectory"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
-                    Save Directory (Optional)
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={settings?.savegamesPath || ''}
-                      className="bg-app-primary border-app"
-                      {...field}
-                      value={field.value || ''}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="launchParameters"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
-                    Launch Parameters (Optional)
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="-skill 4 -warp 01"
-                      className="bg-app-primary border-app"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
+                  Description (Optional)
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Enter a fitting description"
+                    className="bg-app-primary border-app"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         </div>
+
+        {/* Advanced — occasional per-protocol overrides, collapsed by default */}
+        <div className="border border-app rounded-xl bg-app-secondary overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((open) => !open)}
+            className="w-full flex items-center justify-between gap-3 px-4 py-3 text-xs uppercase tracking-widest text-app-muted font-mono font-bold hover:text-app-primary hover:bg-app-hover transition-colors"
+          >
+            <span>Advanced — base WAD &amp; source port, save path, isolated config</span>
+            <ChevronDown
+              className={`w-4 h-4 shrink-0 transition-transform ${advancedOpen ? 'rotate-180' : ''}`}
+            />
+          </button>
+
+          {advancedOpen && (
+            <div className="p-4 pt-0 space-y-4 border-t border-app">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
+                <FormField
+                  control={form.control}
+                  name="doomVersionId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
+                        Base WAD
+                      </FormLabel>
+                      {/* key forces a fresh mount the instant a value is first
+                          set programmatically (our default-fill effect in
+                          InstallPage) — without it, Radix Select's onValueChange
+                          spontaneously fires with '' right after a value is set
+                          on an already-mounted-empty instance, resetting the
+                          pre-fill before the user ever sees it. */}
+                      <Select
+                        key={field.value ? 'has-value' : 'no-value'}
+                        onValueChange={field.onChange}
+                        value={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="bg-app-primary border-app">
+                            <SelectValue placeholder="Select Base Game/Version" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent className="bg-app-secondary border-app text-app-primary">
+                          {versions
+                            .filter((v) => !v.ignored)
+                            .map((version) => (
+                              <SelectItem key={version.id} value={version.id.toString()}>
+                                {version.name}
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="sourcePortId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
+                        Source Port
+                      </FormLabel>
+                      <FormControl>
+                        <Combobox
+                          value={field.value}
+                          onValueChange={field.onChange}
+                          options={(settings?.sourcePorts || [])
+                            .filter((p) => !p.ignored)
+                            .map((p) => ({
+                              value: p.id,
+                              label: p.name,
+                              description: p.version
+                            }))}
+                          placeholder="Select a source port"
+                          className="w-full bg-app-primary border-app"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="saveDirectory"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
+                        Save Directory (Optional)
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder={settings?.savegamesPath || ''}
+                          className="bg-app-primary border-app"
+                          {...field}
+                          value={field.value || ''}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="launchParameters"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs uppercase tracking-widest text-app-muted font-mono font-bold">
+                        Launch Parameters (Optional)
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="-skill 4 -warp 01"
+                          className="bg-app-primary border-app"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="isolatedConfig"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start gap-3 rounded-lg border border-app bg-app-primary p-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        className="mt-0.5"
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel className="text-sm font-normal text-app-primary cursor-pointer">
+                        Create an isolated config for this protocol
+                      </FormLabel>
+                      <p className="text-xs text-app-muted">
+                        A private copy of the source port&apos;s current settings, so changes here
+                        won&apos;t affect other protocols. Created automatically when you save.
+                      </p>
+                    </div>
+                  </FormItem>
+                )}
+              />
+
+              {templateSeedName && !isolatedConfigChecked && (
+                <p className="text-xs text-app-muted italic">
+                  This protocol will use the saved config from &quot;{templateSeedName}&quot;
+                  unless you check the box above.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
         <Separator />
-        <ProtocolConfigControl
-          hasConfig={configStatus.hasConfig}
-          statusText={configStatus.statusText}
-          onCreateFresh={onCreateFreshConfig}
-          isCreating={isCreatingConfig}
-          variant="section"
-        />
         <div>
           <ModFileSelector value={files} onChange={handleFilesChange} fileReorder={fileReorder} />
         </div>

--- a/src/renderer/src/components/install/ConfigurationTab.tsx
+++ b/src/renderer/src/components/install/ConfigurationTab.tsx
@@ -23,7 +23,6 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Combobox } from '@/components/ui/combobox'
-import { Separator } from '@/components/ui/separator'
 import { ModFileSelector } from '@/components/ModFileSelector'
 import { LaunchCommandPreview } from '@/components/install/LaunchCommandPreview'
 import { FolderOpen, FlaskConical, Plus, ChevronDown } from 'lucide-react'
@@ -377,8 +376,7 @@ export const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
           )}
         </div>
 
-        <Separator />
-        <div>
+        <div className="bg-app-secondary p-4 rounded-xl border border-app shadow-sm">
           <ModFileSelector value={files} onChange={handleFilesChange} fileReorder={fileReorder} />
         </div>
 

--- a/src/renderer/src/lib/install/schema.ts
+++ b/src/renderer/src/lib/install/schema.ts
@@ -7,5 +7,6 @@ export const formSchema = z.object({
   sourcePortId: z.string().min(1, 'Source port is required'),
   saveDirectory: z.string().optional(),
   screenshotPath: z.string().optional(),
-  launchParameters: z.string().optional()
+  launchParameters: z.string().optional(),
+  isolatedConfig: z.boolean().optional()
 })

--- a/src/renderer/src/pages/InstallPage.tsx
+++ b/src/renderer/src/pages/InstallPage.tsx
@@ -33,13 +33,13 @@ export const InstallPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState('install')
   // const [currentFilePath, setCurrentFilePath] = useState<string>('');
 
-  // Generated up front (not at submit time) so a fresh protocol config can be
-  // created against a real, stable ID while the form is still being filled
-  // out. InstallPage fully unmounts on navigation back to '/', so a fresh
-  // value is naturally generated again next time this page is visited.
+  // Generated up front (not at submit time) so it's stable across the whole
+  // time the form is being filled out — used as the protocol's real id and,
+  // if "isolated config" is checked, as the id a fresh config file is
+  // created against at submit time. InstallPage fully unmounts on
+  // navigation back to '/', so a fresh value is naturally generated again
+  // next time this page is visited.
   const [pendingProtocolId] = useState(() => Date.now().toString())
-  const [freshConfig, setFreshConfig] = useState<{ configFile: string } | null>(null)
-  const [isCreatingConfig, setIsCreatingConfig] = useState(false)
 
   // Fetch doom versions
   const { data: versions = [] } = useQuery<IDoomVersion[]>({
@@ -95,7 +95,8 @@ export const InstallPage: React.FC = () => {
       doomVersionId: '',
       sourcePortId: defaultPortId,
       saveDirectory: '',
-      launchParameters: ''
+      launchParameters: '',
+      isolatedConfig: false
     }
   })
 
@@ -221,42 +222,12 @@ export const InstallPage: React.FC = () => {
   })
 
   // Mod file carrying a config template, if one of the chosen files has one —
-  // used to preview what submitting will auto-seed, unless the user overrides
-  // it with their own fresh config below.
+  // surfaced as a note next to the isolated-config checkbox, since checking
+  // it overrides this auto-seed (see onSubmit).
   const templateFile = files.find((f) => f.configTemplate)
-
-  const configStatus = freshConfig
-    ? { hasConfig: true, statusText: `Custom config linked (${freshConfig.configFile}).` }
-    : templateFile?.configTemplate
-      ? {
-          hasConfig: true,
-          statusText: `Will be seeded from "${templateFile.name || templateFile.fileName}" when created.`
-        }
-      : {
-          hasConfig: false,
-          statusText:
-            "No isolated config yet — this protocol will share the source port's global settings."
-        }
-
-  const handleCreateFreshConfig = async (): Promise<void> => {
-    setIsCreatingConfig(true)
-    try {
-      const result = await api.createBlankConfig(pendingProtocolId)
-      setFreshConfig(result)
-      toast({
-        title: 'SYSTEM: config_created',
-        description: 'Fresh isolated config created for this protocol.'
-      })
-    } catch (error) {
-      toast({
-        title: 'FATAL: config_create_failed',
-        description: `Failed to create config: ${error}`,
-        variant: 'destructive'
-      })
-    } finally {
-      setIsCreatingConfig(false)
-    }
-  }
+  const templateSeedName = templateFile
+    ? templateFile.name || templateFile.fileName || 'a mod file'
+    : null
 
   // const removeFile = (index: number) => {
   //   const newFiles = [...files]
@@ -344,11 +315,23 @@ export const InstallPage: React.FC = () => {
       console.warn('[DEBUG] Failed to update some catalog entries:', err)
     }
 
-    // A user-created fresh config always wins over auto-seeding from a mod's
-    // template — it's an explicit override. Otherwise, seed from a mod's
-    // config template if one of the chosen files has one.
-    if (freshConfig) {
-      protocol.protocolConfig = { configFile: freshConfig.configFile }
+    // An explicit "isolated config" checkbox always wins over auto-seeding
+    // from a mod's template. The config file itself is only created here,
+    // at actual submit time — not when the checkbox is ticked — so
+    // abandoning the form never leaves an orphaned config file on disk for
+    // a protocol that was never created.
+    if (data.isolatedConfig) {
+      try {
+        const result = await api.createBlankConfig(uniqueId)
+        protocol.protocolConfig = { configFile: result.configFile }
+      } catch (error) {
+        toast({
+          title: 'FATAL: config_create_failed',
+          description: `Failed to create isolated config: ${error}`,
+          variant: 'destructive'
+        })
+        return
+      }
     } else if (templateFile?.configTemplate) {
       try {
         const protocolConfig = await api.copyConfigForProtocol(
@@ -447,9 +430,7 @@ export const InstallPage: React.FC = () => {
                     toast={toast}
                     onSubmit={onSubmit}
                     handleFilesChange={handleFilesChange}
-                    configStatus={configStatus}
-                    onCreateFreshConfig={handleCreateFreshConfig}
-                    isCreatingConfig={isCreatingConfig}
+                    templateSeedName={templateSeedName}
                   />
                 </TabsContent>
 

--- a/src/renderer/src/pages/InstallPage.tsx
+++ b/src/renderer/src/pages/InstallPage.tsx
@@ -111,6 +111,18 @@ export const InstallPage: React.FC = () => {
     }
   }, [settings, form])
 
+  // Update doomVersionId default when settings/versions load — mirrors the
+  // sourcePortId default above.
+  useEffect(() => {
+    if (versions.length > 0 && !form.getValues('doomVersionId')) {
+      const defaultId =
+        (settings as IAppSettings).defaultDoomVersionId ||
+        versions.find((v) => !v.ignored)?.id ||
+        versions[0].id
+      form.setValue('doomVersionId', defaultId)
+    }
+  }, [settings, versions, form])
+
   // Compute launch command preview
   const watchedSourcePortId = form.watch('sourcePortId')
   const watchedDoomVersionId = form.watch('doomVersionId')

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -131,6 +131,7 @@ export interface ModProtocolConfig {
 export interface IAppSettings {
   sourcePorts: ISourcePort[]
   defaultSourcePortId?: string
+  defaultDoomVersionId?: string
   theme: ThemeMode
   savegamesPath?: string
   modsDirectory?: string


### PR DESCRIPTION
## What

Two related improvements to how protocols are configured.

### 1. Default Base WAD setting

Adds a **Default Base WAD** setting — the same pattern as the existing default Source Port. Settable via a radio-dot in the WAD Config tab (`SettingsDialog`); when a new protocol is created, Base WAD auto-fills from this default the same way Source Port already does.

**Bug fix included:** Radix UI `Select` has a subtle bug where it silently resets a programmatically-set value back to empty right after it's set. Worked around by keying the `Select` on whether it has a value yet, forcing a clean remount so the programmatic value sticks.

### 2. Configuration tab redesign

The InstallPage `ConfigurationTab` fields are now grouped into:

- **Protocol Identity** panel — Label, Screenshot/Cover, Description (kept visible since these are what make protocols recognizable in the library).
- Collapsed **Advanced** section — Base WAD + Source Port overrides, Save Directory, Launch Parameters, and a new **Isolated Config** checkbox.

The checkbox replaces the old **Create Unique Config** button. That button eagerly created a config file on disk the moment it was clicked — even if the user then abandoned the form, leaving an orphaned file. The new checkbox is just a flag; the config is only created atomically alongside the protocol at actual submit time.

## Test plan

- [x] `npm run typecheck && npm run lint && npm test` — 104 unit tests pass on both commits
- [x] Both features verified end-to-end via a real Electron launch under xvfb:
  - Default WAD confirmed to auto-fill Base WAD with the correct resolved launch command
  - Isolated-config checkbox confirmed to fire zero API calls until submit, then config-create and protocol-create calls fire together and the resulting protocol correctly links to the new config file (test protocol cleaned up afterward via the API)