### PR TITLE
fix: show achievement name in unlock toast title instead of generic "ACHIEVEMENT UNLOCKED"

### DIFF
--- a/src/renderer/src/lib/achievements/triggers.ts
+++ b/src/renderer/src/lib/achievements/triggers.ts
@@ -190,8 +190,8 @@ export function buildUnlockToasts(
     } else {
       toasts.push({
         id: `achiev-${def.id}`,
-        title: 'ACHIEVEMENT UNLOCKED',
-        description: `${def.title} — ${def.description}`,
+        title: `"${def.title}" Unlocked!`,
+        description: def.description,
         duration: 6000
       })
     }

--- a/src/renderer/src/lib/notifications.test.ts
+++ b/src/renderer/src/lib/notifications.test.ts
@@ -93,7 +93,7 @@ describe('recordNotification filtering', () => {
       { title: 'FATAL: process_died', variant: 'destructive' as const }
     ],
     ['a WARNING: title', { title: 'WARNING: name_required' }],
-    ['an achievement unlock', { title: 'ACHIEVEMENT UNLOCKED' }],
+    ['an achievement unlock', { title: '"Doom Slayer" Unlocked!' }],
     ['a rank advancement', { title: 'RANK ADVANCEMENT' }],
     ['an update status toast', { title: 'SYSTEM: Update Ready' }]
   ])('records %s', async (_label, props) => {

--- a/src/renderer/src/lib/notifications.ts
+++ b/src/renderer/src/lib/notifications.ts
@@ -65,7 +65,7 @@ function emit(): void {
 function shouldRecord(title: string, variant: 'default' | 'destructive'): boolean {
   if (variant === 'destructive') return true
   if (title.startsWith('WARNING:')) return true
-  if (title === 'ACHIEVEMENT UNLOCKED' || title === 'RANK ADVANCEMENT') return true
+  if (title.endsWith('" Unlocked!') || title === 'RANK ADVANCEMENT') return true
   if (title.startsWith('SYSTEM: Update')) return true
   return false
 }


### PR DESCRIPTION
## What changed

- **`triggers.ts`**: Toast title changed from the generic `"ACHIEVEMENT UNLOCKED"` to `"<Achievement Name> Unlocked!"` and description now shows only the achievement description (was concatenating title + description).
- **`notifications.ts`**: `shouldRecord` filter updated from exact match on `"ACHIEVEMENT UNLOCKED"` to suffix match on `endsWith('" Unlocked!')` so dynamic achievement toasts still get persisted.
- **`notifications.test.ts`**: Test expectation updated to match the new title format.

## Why

The unlock toast was showing a static "ACHIEVEMENT UNLOCKED" title for every achievement, making it impossible to tell which achievement was unlocked without reading the description. Now the achievement name appears in the title, which is what the UX intended.

## Notes for reviewers

The `shouldRecord` guard in `notifications.ts` uses `endsWith` on `'" Unlocked!'` — if other toasts ever need the same pattern, consider extracting a named constant or a prefix-based approach. This is fine for the current single use case.
