### PR TITLE
chore: reflow long text line in ConfigurationTab to satisfy lint

### DIFF
--- a/src/renderer/src/components/install/ConfigurationTab.tsx
+++ b/src/renderer/src/components/install/ConfigurationTab.tsx
@@ -368,8 +368,8 @@ export const ConfigurationTab: React.FC<ConfigurationTabProps> = ({
 
               {templateSeedName && !isolatedConfigChecked && (
                 <p className="text-xs text-app-muted italic">
-                  This protocol will use the saved config from &quot;{templateSeedName}&quot;
-                  unless you check the box above.
+                  This protocol will use the saved config from &quot;{templateSeedName}&quot; unless
+                  you check the box above.
                 </p>
               )}
             </div>


### PR DESCRIPTION
## What

Reflowed a long text line in `ConfigurationTab.tsx` to break at the word boundary instead of mid-string, fixing a line-length lint warning.

## Why

Keeps the codebase lint-clean with no outstanding prettier warnings — aligns with the `chore/lint-cleanup` branch goal.

## Notes for reviewers

- Zero behavior change: the rendered text is identical.
- Single file, two lines touched.